### PR TITLE
use webkit audiocontext for older safari versions

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -57,6 +57,7 @@ export function init(options = {}, ee = EventEmitter()) {
   }
 
   const playlist = new Playlist();
+  const AudioContext = window.AudioContext || window.webkitAudioContext || false
   const ctx = config.ac || new AudioContext();
   playlist.setAudioContext(ctx);
   playlist.setSampleRate(config.sampleRate || ctx.sampleRate);


### PR DESCRIPTION
Avoid errors when creating the AudioContext in Safari 14.
Fix: 
```javascript
 AudioContext = window.AudioContext || window.webkitAudioContext || false
```